### PR TITLE
Feat : signup api 500 error 반환 수정

### DIFF
--- a/src/main/kotlin/com/everywaffle/team3server/auth/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/everywaffle/team3server/auth/JwtAuthenticationFilter.kt
@@ -48,6 +48,6 @@ class JwtAuthenticationFilter(private val jwtTokenProvider: JwtTokenProvider) : 
     }
 
     private fun isExcludedPath(path: String): Boolean {
-        return path.startsWith("/api/signin") || path.startsWith("/api/signup") || path.startsWith("/test-page")
+        return path.startsWith("/signin") || path.startsWith("/signup") || path.startsWith("/test-page")
     }
 }

--- a/src/main/kotlin/com/everywaffle/team3server/auth/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/everywaffle/team3server/auth/JwtAuthenticationFilter.kt
@@ -15,7 +15,7 @@ class JwtAuthenticationFilter(private val jwtTokenProvider: JwtTokenProvider) : 
     ) {
         val httpRequest = request as HttpServletRequest
 
-        if (isExcludedPath(httpRequest.pathInfo)) {
+        if (isExcludedPath("/" + httpRequest.requestURI.substringAfterLast("/"))) {
             chain.doFilter(request, response)
             return
         }

--- a/src/main/kotlin/com/everywaffle/team3server/user/controller/UserSignUpController.kt
+++ b/src/main/kotlin/com/everywaffle/team3server/user/controller/UserSignUpController.kt
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -17,6 +18,7 @@ class UserSignUpController(
     private val userSignUpService: UserSignUpService
 ) {
     @PostMapping("/api/signup")
+    @ResponseBody
     fun signup(
         @RequestBody request: UserRequest.SignUpRequest,
     ): UserResponse.SignUpResponse {

--- a/src/main/kotlin/com/everywaffle/team3server/user/controller/UserSignUpController.kt
+++ b/src/main/kotlin/com/everywaffle/team3server/user/controller/UserSignUpController.kt
@@ -10,7 +10,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -18,7 +17,6 @@ class UserSignUpController(
     private val userSignUpService: UserSignUpService
 ) {
     @PostMapping("/api/signup")
-    @ResponseBody
     fun signup(
         @RequestBody request: UserRequest.SignUpRequest,
     ): UserResponse.SignUpResponse {

--- a/src/test/kotlin/com/everywaffle/team3server/auth/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/com/everywaffle/team3server/auth/JwtAuthenticationFilterTest.kt
@@ -34,7 +34,7 @@ class JwtAuthenticationFilterTest {
     @Test
     fun `When path is excluded, filter should not check token`() {
         // 토큰 검증 대상 path가 아닌 경우, filter가 token을 체크하지 않는지 확인
-        request.pathInfo = "/api/signin"
+        request.requestURI = "/api/signin"
 
         jwtAuthenticationFilter.doFilter(request, response, filterChain)
 


### PR DESCRIPTION
확인 결과 pathInfo 함수도 null값을 반환해서 생긴 문제였습니다. 이를 방지하기 위해 substring 함수로 직접 url을 파싱해 처리했습니다.
postman을 이용해 정상적으로 작동하는 것 확인하였습니다.