### PR TITLE
글 댓글 및 대댓글 조회 기능 구현

### DIFF
--- a/src/main/kotlin/com/everywaffle/team3server/comment/controller/PostCommentController.kt
+++ b/src/main/kotlin/com/everywaffle/team3server/comment/controller/PostCommentController.kt
@@ -1,0 +1,21 @@
+package com.everywaffle.team3server.comment.controller
+
+import com.everywaffle.team3server.comment.dto.CommentResponse
+import com.everywaffle.team3server.comment.service.CommentService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/post")
+class PostCommentController(private val commentService: CommentService) {
+    @GetMapping("/{postId}/comments")
+    fun getCommentsByPostId(
+        @PathVariable postId: Long,
+    ): ResponseEntity<List<CommentResponse.CommentDetailList>> {
+        val comments = commentService.getCommentsByPostId(postId)
+        return ResponseEntity.ok(comments)
+    }
+}

--- a/src/main/kotlin/com/everywaffle/team3server/comment/dto/CommentResponse.kt
+++ b/src/main/kotlin/com/everywaffle/team3server/comment/dto/CommentResponse.kt
@@ -10,5 +10,16 @@ class CommentResponse {
         val content: String,
         val parentCommentId: Long?,
         val createdAt: Date,
+        val likes: Int,
+    )
+
+    data class CommentDetailList(
+        val id: Long,
+        val userId: Long,
+        val postId: Long,
+        val content: String,
+        val createdAt: Date,
+        val childComments: List<CommentDetail> = listOf(),
+        val likes: Int,
     )
 }

--- a/src/main/kotlin/com/everywaffle/team3server/comment/repository/CommentRepository.kt
+++ b/src/main/kotlin/com/everywaffle/team3server/comment/repository/CommentRepository.kt
@@ -3,4 +3,6 @@ package com.everywaffle.team3server.comment.repository
 import com.everywaffle.team3server.comment.model.CommentEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CommentRepository : JpaRepository<CommentEntity, Long>
+interface CommentRepository : JpaRepository<CommentEntity, Long> {
+    fun findByPostPostIdOrderByCreatedAt(postId: Long): List<CommentEntity>
+}

--- a/src/main/kotlin/com/everywaffle/team3server/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/everywaffle/team3server/comment/service/CommentService.kt
@@ -12,4 +12,6 @@ interface CommentService {
     ): CommentResponse.CommentDetail
 
     fun deleteComment(commentId: Long)
+
+    fun getCommentsByPostId(postId: Long): List<CommentResponse.CommentDetailList>
 }


### PR DESCRIPTION
글 댓글 및 대댓글 조회 기능 구현완료하였습니다.

프론트에서 사용하기 좋도록 댓글 - 대댓글 위상 관계 지키면서 시간순으로 조회되도록 구현하였습니다.

아래의 예시 response 참고하시면 됩니다.

<img width="393" alt="스크린샷 2024-01-16 오후 4 09 44" src="https://github.com/wafflestudio21-5/team3-server/assets/79765552/c4d86927-dfe6-4a56-8d46-ba7a3b081376">   .
<img width="395" alt="스크린샷 2024-01-16 오후 4 09 53" src="https://github.com/wafflestudio21-5/team3-server/assets/79765552/0852feea-b4ef-448b-9e75-f7a94a303794">   
<img width="394" alt="스크린샷 2024-01-16 오후 4 09 59" src="https://github.com/wafflestudio21-5/team3-server/assets/79765552/d6b60a78-40ee-42f8-a007-028cf3002a92">   
